### PR TITLE
change line 28 RUN to CMD

### DIFF
--- a/images/qbitmf/Dockerfile
+++ b/images/qbitmf/Dockerfile
@@ -25,7 +25,7 @@ RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr . \
 # Build qbittorrent
 ADD deps/qbittorrent-multiface /qbittorrent-multiface
 WORKDIR /qbittorrent-multiface
-RUN ./configure --disable-gui \
+CMD ./configure --disable-gui \
     && make -j$(nproc) \
     && make install
 


### PR DESCRIPTION
RUN resulted in permission errors when running the build script.
```
Step 8/18 : RUN ./configure --disable-gui     && make -j$(nproc)     && make install
 ---> Running in aed5e6a835ba
/bin/sh: 1: ./configure: Permission denied
The command '/bin/sh -c ./configure --disable-gui     && make -j$(nproc)     && make install' returned a non-zero code: 126
ERROR: Service 'qbitmf' failed to build : Build failed
```
CMD fixed the error and the build completed